### PR TITLE
Use appropriate terms to refer the existing Android UI toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ sense.
 ### Interoperability
 |Example|Preview|
 |-------|-------|
-|[How can I use Jetpack Compose components inside existing screens?](https://github.com/vinaygaba/Learn-Jetpack-Compose-By-Example/blob/master/app/src/androidTest/java/com/example/jetpackcompose/interop/ComposeInLegacyAndroidActivity.kt) | <img src ="screenshots/interop.png" width=214 height=400>|
+|[How can I use Jetpack Compose components inside existing screens?](https://github.com/vinaygaba/Learn-Jetpack-Compose-By-Example/blob/master/app/src/androidTest/java/com/example/jetpackcompose/interop/ComposeInClassicAndroidActivity.kt) | <img src ="screenshots/interop.png" width=214 height=400>|
 
 ### Testing
 |Example|Preview|

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -169,9 +169,9 @@
             android:label="@string/title_animation_example"
             android:theme="@style/AppTheme.NoActionBar" />
         <activity 
-            android:name=".interop.ComposeInLegacyAndroidActivity"
+            android:name=".interop.ComposeInClassicAndroidActivity"
             android:exported="true"
-            android:label="@string/title_compose_legacy_example"
+            android:label="@string/title_compose_classic_example"
             android:theme="@style/AppTheme.NoActionBar" />
         <activity
             android:name=".customview.MeasuringScaleActivity"

--- a/app/src/main/java/com/example/jetpackcompose/core/MainActivity.kt
+++ b/app/src/main/java/com/example/jetpackcompose/core/MainActivity.kt
@@ -14,7 +14,7 @@ import com.example.jetpackcompose.customview.CustomViewPainActivity
 import com.example.jetpackcompose.customview.MeasuringScaleActivity
 import com.example.jetpackcompose.material.ShadowActivity
 import com.example.jetpackcompose.image.ImageActivity
-import com.example.jetpackcompose.interop.ComposeInLegacyAndroidActivity
+import com.example.jetpackcompose.interop.ComposeInClassicAndroidActivity
 import com.example.jetpackcompose.layout.ConstraintLayoutActivity
 import com.example.jetpackcompose.layout.LayoutModifierActivity
 import com.example.jetpackcompose.scrollers.HorizontalScrollableActivity
@@ -162,8 +162,8 @@ class MainActivity : AppCompatActivity() {
         startActivity(Intent(this, CoroutineFlowActivity::class.java))
     }
     
-    fun startComposeLegacyExample(view: View) {
-        startActivity(Intent(this, ComposeInLegacyAndroidActivity::class.java))
+    fun startComposeWithClassicAndroidExample(view: View) {
+        startActivity(Intent(this, ComposeInClassicAndroidActivity::class.java))
     }
     
     fun startMeasuringScaleExample(view: View) {

--- a/app/src/main/java/com/example/jetpackcompose/interop/ComposeInClassicAndroidActivity.kt
+++ b/app/src/main/java/com/example/jetpackcompose/interop/ComposeInClassicAndroidActivity.kt
@@ -24,17 +24,17 @@ import androidx.ui.unit.sp
 import com.example.jetpackcompose.R
 import com.example.jetpackcompose.core.colors
 
-class ComposeInLegacyAndroidActivity : AppCompatActivity() {
+class ComposeInClassicAndroidActivity : AppCompatActivity() {
     private lateinit var containerLayout: FrameLayout
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_compose_in_legacy_android)
+        setContentView(R.layout.activity_compose_in_classic_android)
         containerLayout = findViewById(R.id.frame_container)
         // We make use of the setContent extension function that's available for all view groups.
         // This allows us to render a @Composable function inside a view group. This allows us to
-        // render composables inside legacy views. In the example below, we use the frame layout 
-        // called containerLayout and pass the composable called CardComponentWithMessage to 
+        // render composables inside classic android views. In the example below, we use the frame 
+        // layout called containerLayout and pass the composable called CardComponentWithMessage to 
         // render inside it.
         containerLayout.setContent(Recomposer.current()) {
             CardComponentWithMessage()
@@ -70,7 +70,8 @@ fun CardComponentWithMessage() {
         ) {
             // Text is a predefined composable that does exactly what you'd expect it to - display text on
             // the screen. It allows you to customize its appearance using style, fontWeight, fontSize, etc.
-            Text("This is an example of a Jetpack Compose composable inside a legacy Android view", 
+            Text("This is an example of a Jetpack Compose composable inside a classic Android " +
+                    "view", 
                 style = TextStyle(
                     fontFamily = FontFamily.Monospace, 
                     fontWeight = FontWeight.W900, 

--- a/app/src/main/res/layout/activity_compose_in_classic_android.xml
+++ b/app/src/main/res/layout/activity_compose_in_classic_android.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".interop.ComposeInLegacyAndroidActivity">
+    tools:context=".interop.ComposeInClassicAndroidActivity">
     
     <FrameLayout
         android:id="@+id/frame_container"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -583,18 +583,18 @@
         </androidx.cardview.widget.CardView>
 
         <androidx.cardview.widget.CardView
-            android:id="@+id/load_compose_legacy_example"
+            android:id="@+id/load_compose_classic_android_example"
             android:layout_width="match_parent"
             android:layout_height="@dimen/cardview_height"
             app:cardBackgroundColor="@color/colorPrimary"
             android:padding="@dimen/default_padding"
-            android:onClick="startComposeLegacyExample"
+            android:onClick="startComposeWithClassicAndroidExample"
             android:layout_marginTop="@dimen/default_padding"
             app:cardCornerRadius="@dimen/card_corner_radius">
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/tv_compose_legacy_example"
+                android:text="@string/tv_compose_classic_example"
                 android:textColor="@color/white"
                 android:layout_gravity="center"
                 android:fontFamily="monospace"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
     <string name="title_filter_chips_example">Filter Chips Example</string>
     <string name="title_shadow_example">Shadow Example</string>
     <string name="title_coroutine_flow_example">Coroutine Flow Example</string>
-    <string name="title_compose_legacy_example">Compose In Legacy Android Example</string>
+    <string name="title_compose_classic_example">Compose In Classic Android Example</string>
     <string name="title_measuring_scale_example">Measuring Scale Example</string>
 
     <string name="tv_simple_text_example">Display Text</string>
@@ -60,6 +60,6 @@
     <string name="tv_filter_chips_example">Filter Chips Component</string>
     <string name="tv_shadow_example">Shadow Component</string>
     <string name="tv_coroutine_flow_example">Coroutine Flow Component</string>
-    <string name="tv_compose_legacy_example">Compose In Legacy Android Component</string>
+    <string name="tv_compose_classic_example">Compose In Classic Android Component</string>
     <string name="tv_measuring_scale_example">Measuring Scale Component</string>
 </resources>


### PR DESCRIPTION
It's important to use the correct terms to refer the existing Android UI toolkit. 
Related discussion - https://kotlinlang.slack.com/archives/CJLTWPH7S/p1591981867137300