### PR TITLE
Typos in comment documentation for tutorial

### DIFF
--- a/app/src/androidTest/java/com/example/jetpackcompose/text/SimpleTextComposableTest.kt
+++ b/app/src/androidTest/java/com/example/jetpackcompose/text/SimpleTextComposableTest.kt
@@ -38,7 +38,7 @@ class SimpleTextComposableTest {
     fun check_if_app_launched_and_displayed_text() {
         // findByText is a helper method that looks for a composable component that contains the
         // text passed to it. It returns a SemanticsNodeInteraction, which allows us to do a
-        // bunch of checks(isDisplayed, isToggelable, etc) and interactions(like click, scroll, etc)
+        // bunch of checks(isDisplayed, isToggleable, etc) and interactions(like click, scroll, etc)
 
 
         // In this example, we just check if there is a composable with the text

--- a/app/src/main/java/com/example/jetpackcompose/animation/Animation1Activity.kt
+++ b/app/src/main/java/com/example/jetpackcompose/animation/Animation1Activity.kt
@@ -53,14 +53,14 @@ fun RotatingSquareComponent() {
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
         content = {
-            // rememberInfiniteTransition is used to create a transition that uses infitine
+            // rememberInfiniteTransition is used to create a transition that uses infinite
             // child animations. Animations typically get invoked as soon as they enter the
             // composition so don't need to be explicitly started.
             val infiniteTransition = rememberInfiniteTransition()
 
             // Create a value that is altered by the transition based on the configuration. We use
             // the animated float value the returns and updates a float from the initial value to
-            // target value and repeats it (as its called on the infititeTransition).
+            // target value and repeats it (as its called on the infiniteTransition).
             val rotation by infiniteTransition.animateFloat(
                 initialValue = 0f,
                 targetValue = 360f,
@@ -81,7 +81,7 @@ fun RotatingSquareComponent() {
                 // As the Transition is changing the interpolating the value of the animated float
                 // "rotation", you get access to all the values including the intermediate values as
                 // its  being updated. The value of "rotation" goes from 0 to 360 and transitions
-                // infinitely due to the infiniteRepetable animationSpec used above.
+                // infinitely due to the infiniteRepeatable animationSpec used above.
                 rotate(rotation) {
                     drawRect(color = Color(255, 138, 128))
                 }

--- a/app/src/main/java/com/example/jetpackcompose/animation/ListAnimationActivity.kt
+++ b/app/src/main/java/com/example/jetpackcompose/animation/ListAnimationActivity.kt
@@ -81,7 +81,7 @@ fun ListAnimationComponent(personList: List<Person>) {
         itemsIndexed(items = personList,
             itemContent = { index, person ->
                 // AnimatedVisibility is a pre-defined composable that automatically animates the 
-                // appearace and disappearance of it's content. This makes it super easy to animated 
+                // appearance and disappearance of it's content. This makes it super easy to animated
                 // things like insertion/deletion of a list element. The visible property tells the
                 // AnimatedVisibility about whether to show the composable that it wraps (in this case, 
                 // the Card that you see below). This is where you can add logic about whether a certain 

--- a/app/src/main/java/com/example/jetpackcompose/animation/TextAnimationActivity.kt
+++ b/app/src/main/java/com/example/jetpackcompose/animation/TextAnimationActivity.kt
@@ -65,7 +65,7 @@ fun TextAnimationComponent() {
         // composable that we will replace by other composables tagged with the same id. For 
         // example, we add two sections with id's "composeLogo" & "animatedText" below. We will 
         // reference the same id's in the inlineContent map that we will be passing to the Text 
-        // Commposable.
+        // Composable.
         appendInlineContent("composeLogo", "Compose Logo")
         appendInlineContent("animatedText", "Animated Text")
     }
@@ -131,13 +131,13 @@ fun ComposeLogoComponent() {
     // be advisable to use the painterResource method as it loads an image resource asynchronously
     val image = ImageBitmap.imageResource(R.drawable.compose_logo)
 
-    // rememberInfiniteTransition is used to create a transition that uses infitine
+    // rememberInfiniteTransition is used to create a transition that uses infinite
     // child animations. Animations typically get invoked as soon as they enter the
     // composition so don't need to be explicitly started.
     val infiniteTransition = rememberInfiniteTransition()
     // Create a value that is altered by the transition based on the configuration. We use
     // the animated float value the returns and updates a float from the initial value to
-    // target value and repeats it (as its called on the infititeTransition).
+    // target value and repeats it (as its called on the infiniteTransition).
     val rotation by infiniteTransition.animateFloat(
         initialValue = 0f,
         targetValue = 360f,
@@ -156,7 +156,7 @@ fun ComposeLogoComponent() {
         // As the Transition is changing the interpolating the value of the animated float
         // "rotation", you get access to all the values including the intermediate values as
         // its  being updated. The value of "rotation" goes from 0 to 360 and transitions
-        // infinitely due to the infiniteRepetable animationSpec used above.
+        // infinitely due to the infiniteRepeatable animationSpec used above.
         rotate(rotation) {
             drawImage(image)
         }

--- a/app/src/main/java/com/example/jetpackcompose/interop/ComposeInClassicAndroidActivity.kt
+++ b/app/src/main/java/com/example/jetpackcompose/interop/ComposeInClassicAndroidActivity.kt
@@ -52,9 +52,9 @@ fun CardComponentWithMessage() {
 
     // You can think of Modifiers as implementations of the decorators pattern that are
     // used to modify the composable that its applied to. In this example, we configure the
-    // Column composable to occupuy the entire available width and height using
+    // Column composable to occupy the entire available width and height using
     // Modifier.fillMaxSize() and center the content inside the Column using the appropriate 
-    // veritical arrangement & horizontal alignment.
+    // vertical arrangement & horizontal alignment.
     Column(
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.Center,

--- a/app/src/main/java/com/example/jetpackcompose/layout/ConstraintLayoutActivity.kt
+++ b/app/src/main/java/com/example/jetpackcompose/layout/ConstraintLayoutActivity.kt
@@ -185,7 +185,7 @@ fun GuidelineConstraintLayoutComponent() {
             // our composable layouts. In order to apply these constraints to a 
             // composable(view/layout), we reference these references to impose the respective 
             // constraint on that composable. Look at how each of these references are being 
-            // reference below using the Modifier.contrainAs modifier.
+            // reference below using the Modifier.constrainAs modifier.
             val (text1, text2) = createRefs()
 
             // Create a guideline that's placed at a 25% width percentage from the left of the
@@ -204,7 +204,7 @@ fun GuidelineConstraintLayoutComponent() {
             // In order to apply the constraints to the references that we created above, we make 
             // use of the Modifier.constrainAs modifier and pass the reference to it in order to 
             // create a mapping between the composable/layout and the reference. We then add 
-            // contraints to the references inside the lambda passed to the constrainAs modifier.
+            // constraints to the references inside the lambda passed to the constrainAs modifier.
             Text(
                 "Quarter", style = TextStyle(
                     fontFamily = FontFamily.Serif, fontWeight =
@@ -258,7 +258,7 @@ fun BarrierConstraintLayoutComponent() {
             // our composable layouts. In order to apply these constraints to a 
             // composable(view/layout), we reference these references to impose the respective 
             // constraint on that composable. Look at how each of these references are being 
-            // reference below using the Modifier.contrainAs modifier.
+            // reference below using the Modifier.constrainAs modifier.
             val (text1, text2, text3) = createRefs()
 
 
@@ -275,7 +275,7 @@ fun BarrierConstraintLayoutComponent() {
             // In order to apply the constraints to the references that we created above, we make 
             // use of the Modifier.constrainAs modifier and pass the reference to it in order to 
             // create a mapping between the composable/layout and the reference. We then add 
-            // contraints to the references inside the lambda passed to the constrainAs modifier.
+            // constraints to the references inside the lambda passed to the constrainAs modifier.
             Text(
                 "Short text", style = TextStyle(
                     fontFamily = FontFamily.Serif,

--- a/app/src/main/java/com/example/jetpackcompose/material/FixedActionButtonActivity.kt
+++ b/app/src/main/java/com/example/jetpackcompose/material/FixedActionButtonActivity.kt
@@ -128,7 +128,7 @@ fun ScaffoldWithBottomBarAndCutout() {
  * function that doesn't take any parameters and call your composable function with the appropriate
  * params. Also, don't forget to annotate it with @Preview & @Composable annotations.
  */
-@Preview("Fixed Aaction Button Example")
+@Preview("Fixed Action Button Example")
 @Composable
 fun ScaffoldWithBottomBarAndCutoutPreview() {
     ScaffoldWithBottomBarAndCutout()

--- a/app/src/main/java/com/example/jetpackcompose/state/ProcessDeathActivity.kt
+++ b/app/src/main/java/com/example/jetpackcompose/state/ProcessDeathActivity.kt
@@ -67,7 +67,7 @@ fun ProcessDeathComponent() {
 
     // You can think of Modifiers as implementations of the decorators pattern that are
     // used to modify the composable that its applied to. In this example, we configure the
-    // Column composable to occupuy the entire available width and height using
+    // Column composable to occupy the entire available width and height using
     // Modifier.fillMaxSize() and give center gravity to the content inside this box.
     Column(
         modifier = Modifier.fillMaxSize(),
@@ -169,7 +169,7 @@ class CreditCardVisualTransformation : VisualTransformation {
     }
 }
 
-// Offset map is used to change the position of the cursor based on the transormation being
+// Offset map is used to change the position of the cursor based on the transformation being
 // applied. If no offset is needed for the cursor position, return the same offset value. In the
 // case of CreditCardVisualTransformation, since we add a space character after every 4
 // characters, we need to move the cursor accordingly. For example, if we added 3 space

--- a/app/src/main/java/com/example/jetpackcompose/state/backpress/BackButtonHandler.kt
+++ b/app/src/main/java/com/example/jetpackcompose/state/backpress/BackButtonHandler.kt
@@ -22,14 +22,14 @@ import androidx.compose.ui.platform.LocalContext
 
 // What are LocalCompositions?
 // In Compose, we typically pass data through the composition tree explicitly through means of
-// parameters to composable functions. This is inline with the principles of unidirection 
+// parameters to composable functions. This is inline with the principles of unidirectional
 // data flow that Compose heavily recommends using. There are situations where this won't 
 // always be possible. For these cases, [LocalComposition]s can be used as an implicit way to have
 // data flow through a composition.
 
 // Another way to think about Providers is that I can get access to a value in the middle of 
 // a composition, without having to pass the value in. Some other examples of Providers and 
-// LocalComposiiton's are LocalContext(to get access to the context), etc.
+// LocalComposition's are LocalContext(to get access to the context), etc.
 private val LocalBackPressedDispatcher =
     staticCompositionLocalOf<OnBackPressedDispatcherOwner?> { null }
 
@@ -62,7 +62,7 @@ internal fun handler(
     // mutable properties).  
     val handler = remember { ComposableBackHandler(enabled) }
     // Sometimes we need to make changes to the state of the app. For those cases, Composes provides
-    // some Effect API's which provide a way to perform side effects in a predictable manner.
+    // some Effect APIs which provide a way to perform side effects in a predictable manner.
     // DisposableEffect is one such side effect API that provides a mechanism to perform some
     // clean up actions if the key to the effect changes or if the composable leaves composition.
     DisposableEffect(dispatcher) {

--- a/app/src/main/java/com/example/jetpackcompose/text/CustomTextActivity.kt
+++ b/app/src/main/java/com/example/jetpackcompose/text/CustomTextActivity.kt
@@ -77,7 +77,7 @@ class CustomTextActivity : AppCompatActivity() {
                 // In addition, we pass a modifier to the Row composable. You can think of
                 // Modifiers as implementations of the decorators pattern that  are used to
                 // modify the composable that its applied to. In this example, we configure the
-                // Row to occupify the entire available width using Modifier.fillMaxWidth()
+                // Row to occupy the entire available width using Modifier.fillMaxWidth()
                 CenterTextAlign()
                 // A pre-defined composable that renders a thin line on the screen that makes it
                 // easy to group contents

--- a/app/src/main/java/com/example/jetpackcompose/text/TextFieldActivity.kt
+++ b/app/src/main/java/com/example/jetpackcompose/text/TextFieldActivity.kt
@@ -235,7 +235,7 @@ fun NumberTextInputComponent() {
 @InternalTextApi
 @Composable
 fun SearchImeActionInputComponent() {
-    // LocalContext is a LocalComposition for accessting the context value that we are used to using
+    // LocalContext is a LocalComposition for accessing the context value that we are used to using
     // in Android.
 
     // LocalComposition is an implicit way to pass values down the compose tree. Typically, we pass values


### PR DESCRIPTION
These are all just simple typos in the comments documenting the examples I found while looking through the tutorial for my own learning