### PR TITLE
Update emulator configuration for ui tests

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -36,11 +36,7 @@ jobs:
         run: ./gradlew test --stacktrace
 
   ui-testing:
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        api-level: [26, 28, 29]
-        target: [default, google_apis]
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
@@ -61,8 +57,11 @@ jobs:
       - name: Run UI Tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          emulator-build: 7425822
-          api-level: ${{ matrix.api-level }}
-          target: ${{ matrix.target }}
-          arch: x86_64
+          api-level: 34
+          target: google_apis
+          arch: arm64-v8a
+          force-avd-creation: true
+          disable-animations: true
+          emulator-boot-timeout: 600
+          emulator-options: -no-window -no-snapshot -noaudio -no-boot-anim
           script: ./gradlew connectedCheck --no-daemon --stacktrace


### PR DESCRIPTION
Update Android UI testing workflow to use a modern emulator configuration to fix boot timeout errors.

The previous configuration used an outdated matrix of API levels and targets, and was likely incompatible with current macOS runners and emulator images, leading to the "Timeout waiting for emulator to boot" error. This PR updates the workflow to use macOS 14, a single arm64 API 34 emulator, and adds stable emulator options and a longer boot timeout.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9cf899e-5df3-44fd-9edc-2c5da42f56ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e9cf899e-5df3-44fd-9edc-2c5da42f56ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

